### PR TITLE
fix(reader): image viewer css selector filter

### DIFF
--- a/apps/reader/src/components/Reader.tsx
+++ b/apps/reader/src/components/Reader.tsx
@@ -299,7 +299,11 @@ function BookPane({ tab, onMouseDown }: BookPaneProps) {
         tab.showPrevLocation()
         return
       }
-      if (mobile === false && el.tagName === 'IMG') {
+      if (
+        mobile === false &&
+        el.tagName === 'IMG' &&
+        el.src.startsWith('blob:')
+      ) {
         setSrc(el.src)
         return
       }


### PR DESCRIPTION


<img width="594" alt="image" src="https://github.com/pacexy/flow/assets/990255/1238cba8-8cd8-4566-b358-79271ab00f41">

## ISSUE
The `PhotoSlider` of `react-photo-view` should only applied to the images of the epub content.
but currently, it is applied to all images in the iframe.
for example, in the picture above is a Chrome extension's card UI,
when clicking on the highlight images, will still open the `PhotoSlider` viewer,  which is not work correctly.