### PR TITLE
fix: fix the issue where the name of non-English book fetched through url is garbled

### DIFF
--- a/apps/reader/src/file.ts
+++ b/apps/reader/src/file.ts
@@ -87,7 +87,7 @@ async function toDataUrl(url: string) {
 }
 
 export async function fetchBook(url: string) {
-  const filename = /\/([^/]*\.epub)$/i.exec(url)?.[1] ?? ''
+  const filename = decodeURIComponent(/\/([^/]*)\.epub$/i.exec(url)?.[1] ?? '')
   const books = await db?.books.toArray()
   const book = books?.find((b) => b.name === filename)
 

--- a/apps/reader/src/file.ts
+++ b/apps/reader/src/file.ts
@@ -87,7 +87,7 @@ async function toDataUrl(url: string) {
 }
 
 export async function fetchBook(url: string) {
-  const filename = decodeURIComponent(/\/([^/]*)\.epub$/i.exec(url)?.[1] ?? '')
+  const filename = decodeURIComponent(/\/([^/]*\.epub)$/i.exec(url)?.[1] ?? '')
   const books = await db?.books.toArray()
   const book = books?.find((b) => b.name === filename)
 


### PR DESCRIPTION
There is an issue where the name of non-English book fetched through url is garbled. It is an expected behavior because the browser will automatically encode the invalid character in the url. Using `decodeURIComponent` can fix this issue. Besides, the `.epub` ext. seems to be unnecessary, so I remove it from the file name.