### PR TITLE
feat(reader): support custom fonts

### DIFF
--- a/apps/reader/src/components/Form.tsx
+++ b/apps/reader/src/components/Form.tsx
@@ -26,6 +26,7 @@ export type TextFieldProps<T extends ElementType> = PolymorphicPropsWithoutRef<
     hideLabel?: boolean
     autoFocus?: boolean
     actions?: Action[]
+    datalist?: React.ReactNode[]
     onClear?: () => void
     // https://react-typescript-cheatsheet.netlify.app/docs/basic/getting-started/forward_and_create_ref/#generic-forwardrefs
     mRef?: RefObject<HTMLInputElement> | null
@@ -39,6 +40,7 @@ export function TextField<T extends ElementType = 'input'>({
   hideLabel = false,
   autoFocus,
   actions = [],
+  datalist,
   onClear,
   mRef: outerRef,
   ...props
@@ -46,6 +48,7 @@ export function TextField<T extends ElementType = 'input'>({
   const Component = as || 'input'
   const isInput = Component === 'input'
   const innerRef = useRef<HTMLInputElement>(null)
+  const datalistId = `${name}-datalist` // TODO: use `useId`
   const ref = outerRef || innerRef
   const mobile = useMobile()
   const t = useTranslation()
@@ -83,8 +86,10 @@ export function TextField<T extends ElementType = 'input'>({
             'typescale-body-medium text-on-surface-variant placeholder:text-outline/60 w-0 flex-1 bg-transparent py-1 px-1.5 !text-[13px]',
             isInput || 'scroll h-full resize-none',
           )}
+          {...(datalist && { list: datalistId })}
           {...props}
         />
+        {datalist && <datalist id={datalistId}>{datalist}</datalist>}
         {!!actions.length && (
           <div className="mx-1 flex gap-0.5">
             {actions.map(({ onClick, ...a }) => (

--- a/apps/reader/src/components/viewlets/TypographyView.tsx
+++ b/apps/reader/src/components/viewlets/TypographyView.tsx
@@ -28,11 +28,7 @@ export const TypographyView: React.FC<PaneViewProps> = (props) => {
   const [scope, setScope] = useState(TypographyScope.Book)
   const t = useTranslation('typography')
 
-  const [localFonts, setLocalFonts] = useState<string[]>([
-    'default',
-    'sans-serif',
-    'serif',
-  ])
+  const [localFonts, setLocalFonts] = useState<string[]>()
 
   const { fontFamily, fontSize, fontWeight, lineHeight, zoom, spread } =
     scope === TypographyScope.Book
@@ -106,31 +102,31 @@ export const TypographyView: React.FC<PaneViewProps> = (props) => {
           as="input"
           name={t('font_family')}
           value={fontFamily}
-          datalist={localFonts.map((font) => (
+          // Tips: Datalist only appears on mouse click or keyboard input.
+          // Does not show when focused via Tab/focus() or triggered by click()
+          datalist={localFonts?.map((font) => (
             <option key={font} value={font}>
               {font}
             </option>
           ))}
           onFocus={async () => {
-            if ('queryLocalFonts' in window) {
+            if (!localFonts && 'queryLocalFonts' in window) {
               try {
                 const fonts = await window.queryLocalFonts()
-                const uniqueFontFamilies = Array.from(
-                  new Set(fonts.map((font) => font.family)),
+                const uniqueFonts = Array.from(
+                  new Set(fonts.map((f) => f.family)),
                 )
-                setLocalFonts(['default', ...uniqueFontFamilies])
+                setLocalFonts(uniqueFonts)
+                // FIXME: datalist doesn't appear on first mouse click since
+                // `localFonts` is updated asynchronously after the focus event.
+                // Maybe need to pre-load fonts.
               } catch (error) {
                 console.error('Error querying local fonts:', error)
-                // Fallback fonts are already set in the initial state
               }
             }
-            // If queryLocalFonts is not available, we'll use the fallback fonts set in the initial state
           }}
           onChange={(e) => {
-            setTypography(
-              'fontFamily',
-              e.target.value === 'default' ? undefined : e.target.value,
-            )
+            setTypography('fontFamily', e.target.value)
           }}
         />
         <NumberField

--- a/apps/reader/src/components/viewlets/TypographyView.tsx
+++ b/apps/reader/src/components/viewlets/TypographyView.tsx
@@ -107,11 +107,7 @@ export const TypographyView: React.FC<PaneViewProps> = (props) => {
           name={t('font_family')}
           value={fontFamily}
           datalist={localFonts.map((font) => (
-            <option
-              key={font}
-              value={font}
-              style={{ fontFamily: font !== 'default' ? font : undefined }}
-            >
+            <option key={font} value={font}>
               {font}
             </option>
           ))}

--- a/apps/reader/src/components/viewlets/TypographyView.tsx
+++ b/apps/reader/src/components/viewlets/TypographyView.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { useCallback, useRef, useState, useEffect } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { MdAdd, MdRemove } from 'react-icons/md'
 
 import { RenditionSpread } from '@flow/epubjs/types/rendition'
@@ -16,12 +16,6 @@ import { Select, TextField, TextFieldProps } from '../Form'
 import { PaneViewProps, PaneView, Pane } from '../base'
 
 // Define an interface for the Font object
-interface LocalFont {
-  family: string
-  fullName: string
-  postscriptName: string
-  style: string
-}
 
 enum TypographyScope {
   Book,
@@ -39,33 +33,6 @@ export const TypographyView: React.FC<PaneViewProps> = (props) => {
     'sans-serif',
     'serif',
   ])
-
-  useEffect(() => {
-    const getLocalFonts = async () => {
-      if ('queryLocalFonts' in window) {
-        try {
-          // Type assertion for the window object
-          const queryLocalFonts = (
-            window as Window &
-              typeof globalThis & {
-                queryLocalFonts: () => Promise<LocalFont[]>
-              }
-          ).queryLocalFonts
-          const fonts: LocalFont[] = await queryLocalFonts()
-          const uniqueFontFamilies = Array.from(
-            new Set(fonts.map((font) => font.family)),
-          )
-          setLocalFonts(['default', ...uniqueFontFamilies])
-        } catch (error) {
-          console.error('Error querying local fonts:', error)
-          // Fallback fonts are already set in the initial state
-        }
-      }
-      // If queryLocalFonts is not available, we'll use the fallback fonts set in the initial state
-    }
-
-    getLocalFonts()
-  }, [])
 
   const { fontFamily, fontSize, fontWeight, lineHeight, zoom, spread } =
     scope === TypographyScope.Book
@@ -138,6 +105,22 @@ export const TypographyView: React.FC<PaneViewProps> = (props) => {
         <Select
           name={t('font_family')}
           value={fontFamily ?? 'default'}
+          onFocus={async () => {
+            if ('queryLocalFonts' in window) {
+              try {
+                const fonts = await window.queryLocalFonts()
+                console.log('fonts', fonts)
+                const uniqueFontFamilies = Array.from(
+                  new Set(fonts.map((font) => font.family)),
+                )
+                setLocalFonts(['default', ...uniqueFontFamilies])
+              } catch (error) {
+                console.error('Error querying local fonts:', error)
+                // Fallback fonts are already set in the initial state
+              }
+            }
+            // If queryLocalFonts is not available, we'll use the fallback fonts set in the initial state
+          }}
           onChange={(e) => {
             setTypography(
               'fontFamily',

--- a/apps/reader/src/components/viewlets/TypographyView.tsx
+++ b/apps/reader/src/components/viewlets/TypographyView.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useRef, useState, useEffect } from 'react'
 import { MdAdd, MdRemove } from 'react-icons/md'
 
 import { RenditionSpread } from '@flow/epubjs/types/rendition'
@@ -15,18 +15,57 @@ import { keys } from '@flow/reader/utils'
 import { Select, TextField, TextFieldProps } from '../Form'
 import { PaneViewProps, PaneView, Pane } from '../base'
 
+// Define an interface for the Font object
+interface LocalFont {
+  family: string
+  fullName: string
+  postscriptName: string
+  style: string
+}
+
 enum TypographyScope {
   Book,
   Global,
 }
-
-const typefaces = ['default', 'sans-serif', 'serif']
 
 export const TypographyView: React.FC<PaneViewProps> = (props) => {
   const { focusedBookTab } = useReaderSnapshot()
   const [settings, setSettings] = useSettings()
   const [scope, setScope] = useState(TypographyScope.Book)
   const t = useTranslation('typography')
+
+  const [localFonts, setLocalFonts] = useState<string[]>([
+    'default',
+    'sans-serif',
+    'serif',
+  ])
+
+  useEffect(() => {
+    const getLocalFonts = async () => {
+      if ('queryLocalFonts' in window) {
+        try {
+          // Type assertion for the window object
+          const queryLocalFonts = (
+            window as Window &
+              typeof globalThis & {
+                queryLocalFonts: () => Promise<LocalFont[]>
+              }
+          ).queryLocalFonts
+          const fonts: LocalFont[] = await queryLocalFonts()
+          const uniqueFontFamilies = Array.from(
+            new Set(fonts.map((font) => font.family)),
+          )
+          setLocalFonts(['default', ...uniqueFontFamilies])
+        } catch (error) {
+          console.error('Error querying local fonts:', error)
+          // Fallback fonts are already set in the initial state
+        }
+      }
+      // If queryLocalFonts is not available, we'll use the fallback fonts set in the initial state
+    }
+
+    getLocalFonts()
+  }, [])
 
   const { fontFamily, fontSize, fontWeight, lineHeight, zoom, spread } =
     scope === TypographyScope.Book
@@ -98,14 +137,21 @@ export const TypographyView: React.FC<PaneViewProps> = (props) => {
         </Select>
         <Select
           name={t('font_family')}
-          value={fontFamily}
+          value={fontFamily ?? 'default'}
           onChange={(e) => {
-            setTypography('fontFamily', e.target.value)
+            setTypography(
+              'fontFamily',
+              e.target.value === 'default' ? undefined : e.target.value,
+            )
           }}
         >
-          {typefaces.map((t) => (
-            <option key={t} value={t} style={{ fontFamily: t }}>
-              {t}
+          {localFonts.map((font) => (
+            <option
+              key={font}
+              value={font}
+              style={{ fontFamily: font !== 'default' ? font : undefined }}
+            >
+              {font}
             </option>
           ))}
         </Select>

--- a/apps/reader/src/components/viewlets/TypographyView.tsx
+++ b/apps/reader/src/components/viewlets/TypographyView.tsx
@@ -102,14 +102,23 @@ export const TypographyView: React.FC<PaneViewProps> = (props) => {
             {t('page_view.double_page')}
           </option>
         </Select>
-        <Select
+        <TextField
+          as="input"
           name={t('font_family')}
-          value={fontFamily ?? 'default'}
+          value={fontFamily}
+          datalist={localFonts.map((font) => (
+            <option
+              key={font}
+              value={font}
+              style={{ fontFamily: font !== 'default' ? font : undefined }}
+            >
+              {font}
+            </option>
+          ))}
           onFocus={async () => {
             if ('queryLocalFonts' in window) {
               try {
                 const fonts = await window.queryLocalFonts()
-                console.log('fonts', fonts)
                 const uniqueFontFamilies = Array.from(
                   new Set(fonts.map((font) => font.family)),
                 )
@@ -127,17 +136,7 @@ export const TypographyView: React.FC<PaneViewProps> = (props) => {
               e.target.value === 'default' ? undefined : e.target.value,
             )
           }}
-        >
-          {localFonts.map((font) => (
-            <option
-              key={font}
-              value={font}
-              style={{ fontFamily: font !== 'default' ? font : undefined }}
-            >
-              {font}
-            </option>
-          ))}
-        </Select>
+        />
         <NumberField
           name={t('font_size')}
           min={14}

--- a/apps/reader/src/components/viewlets/TypographyView.tsx
+++ b/apps/reader/src/components/viewlets/TypographyView.tsx
@@ -118,6 +118,7 @@ export const TypographyView: React.FC<PaneViewProps> = (props) => {
           as="input"
           name={t('font_family')}
           value={fontFamily}
+          placeholder="default"
           // Tips: Datalist only appears on mouse click or keyboard input.
           // Does not show when focused via Tab/focus() or triggered by click()
           datalist={localFonts?.map((font) => (

--- a/apps/reader/src/web.d.ts
+++ b/apps/reader/src/web.d.ts
@@ -9,6 +9,14 @@ interface LaunchQueue {
   setConsumer(consumer: (launchParams: LaunchParams) => any): void
 }
 
+interface LocalFont {
+  family: string
+  fullName: string
+  postscriptName: string
+  style: string
+}
+
 interface Window {
   launchQueue: LaunchQueue
+  queryLocalFonts: () => Promise<LocalFont[]>
 }

--- a/apps/reader/tsconfig.json
+++ b/apps/reader/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "experimentalDecorators": true
   },
-  "include": ["next-env.d.ts", "web.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
close #64

This PR improves the font family selection interface by:

1. Replacing the static `<select>` dropdown with a flexible `<input>` field, allowing users to directly type in any font family name
2. Adding support for the Local Font Access API to suggest system fonts:
   - Automatically queries available system fonts when the input is focused or hovered
   - Displays available system fonts in a datalist dropdown
   - Gracefully falls back if the Local Font Access API is not available

## Technical Details
- Uses the `window.queryLocalFonts()` API to access system fonts
- Implements font preloading on hover to ensure suggestions are ready on first click
- Maintains backward compatibility by gracefully handling cases where the API is not supported

## Browser Support
Note: The Local Font Access API is currently supported in Chromium-based browsers (Chrome, Edge, etc.)