### PR TITLE
feat(reader): Implement chapter-limited smooth Scroll View

### DIFF
--- a/apps/reader/locales/en-US.ts
+++ b/apps/reader/locales/en-US.ts
@@ -33,6 +33,7 @@ export default {
   'typography.page_view': 'Page View',
   'typography.page_view.single_page': 'Single Page',
   'typography.page_view.double_page': 'Double Page',
+  'typography.page_view.scroll': 'Scroll',
   'typography.font_family': 'Font Family',
   'typography.font_size': 'Font Size',
   'typography.font_weight': 'Font Weight',

--- a/apps/reader/locales/ja-JP.ts
+++ b/apps/reader/locales/ja-JP.ts
@@ -33,6 +33,7 @@ export default {
   'typography.page_view': 'ページ表示',
   'typography.page_view.single_page': '片ページ',
   'typography.page_view.double_page': '見開きページ',
+  'typography.page_view.scroll': 'スクロール',
   'typography.font_family': 'フォントファミリー',
   'typography.font_size': 'フォントサイズ',
   'typography.font_weight': 'フォントウェイト',

--- a/apps/reader/locales/zh-CN.ts
+++ b/apps/reader/locales/zh-CN.ts
@@ -33,6 +33,7 @@ export default {
   'typography.page_view': '视图',
   'typography.page_view.single_page': '单页',
   'typography.page_view.double_page': '双页',
+  'typography.page_view.scroll': '滚动',
   'typography.font_family': '字体',
   'typography.font_size': '字号',
   'typography.font_weight': '字重',

--- a/apps/reader/src/components/viewlets/TypographyView.tsx
+++ b/apps/reader/src/components/viewlets/TypographyView.tsx
@@ -2,13 +2,13 @@ import clsx from 'clsx'
 import { useCallback, useRef, useState } from 'react'
 import { MdAdd, MdRemove } from 'react-icons/md'
 
-import { RenditionSpread } from '@flow/epubjs/types/rendition'
 import { useTranslation } from '@flow/reader/hooks'
 import { reader, useReaderSnapshot } from '@flow/reader/models'
 import {
   defaultSettings,
   TypographyConfiguration,
   useSettings,
+  PageViewMode,
 } from '@flow/reader/state'
 import { keys } from '@flow/reader/utils'
 
@@ -30,7 +30,7 @@ export const TypographyView: React.FC<PaneViewProps> = (props) => {
 
   const [localFonts, setLocalFonts] = useState<string[]>()
 
-  const { fontFamily, fontSize, fontWeight, lineHeight, zoom, spread } =
+  const { fontFamily, fontSize, fontWeight, lineHeight, zoom, pageViewMode } =
     scope === TypographyScope.Book
       ? focusedBookTab?.book.configuration?.typography ?? defaultSettings
       : settings
@@ -102,16 +102,19 @@ export const TypographyView: React.FC<PaneViewProps> = (props) => {
       >
         <Select
           name={t('page_view')}
-          value={spread ?? RenditionSpread.Auto}
+          value={pageViewMode ?? PageViewMode.Auto}
           onChange={(e) => {
-            setTypography('spread', e.target.value as RenditionSpread)
+            setTypography('pageViewMode', e.target.value as PageViewMode)
           }}
         >
-          <option value={RenditionSpread.None}>
+          <option value={PageViewMode.SinglePage}>
             {t('page_view.single_page')}
           </option>
-          <option value={RenditionSpread.Auto}>
+          <option value={PageViewMode.DoublePage}>
             {t('page_view.double_page')}
+          </option>
+          <option value={PageViewMode.Scrolled}>
+            {t('page_view.scroll')}
           </option>
         </Select>
         <TextField

--- a/apps/reader/src/state.ts
+++ b/apps/reader/src/state.ts
@@ -3,6 +3,13 @@ import { atom, AtomEffect, useRecoilState } from 'recoil'
 
 import { RenditionSpread } from '@flow/epubjs/types/rendition'
 
+export enum PageViewMode {
+  Auto = 'auto',
+  SinglePage = 'single-page',
+  DoublePage = 'double-page',
+  Scrolled = 'scrolled',
+}
+
 function localStorageEffect<T>(key: string, defaultValue: T): AtomEffect<T> {
   return ({ setSelf, onSet }) => {
     if (IS_SERVER) return
@@ -36,7 +43,7 @@ export interface TypographyConfiguration {
   fontWeight?: number
   fontFamily?: string
   lineHeight?: number
-  spread?: RenditionSpread
+  pageViewMode?: PageViewMode
   zoom?: number
 }
 


### PR DESCRIPTION
This commit introduces a refined "Scroll" page view mode that limits vertical scrolling to the current chapter. This addresses the previous issue where continuous scroll modes would either be choppy or scroll across the entire book.

Key changes include:
- Configured EPUB.js rendition with 'scrolled' flow and removed the explicit 'continuous' manager to enable chapter-limited scrolling.
- Modified keyboard event handling in [Reader.tsx](cci:7://file:///Users/pratyushkongalla/space/other/flow/apps/reader/src/components/Reader.tsx:0:0-0:0) to allow explicit chapter navigation (ArrowLeft/Right) when in scroll mode.
- Adjusted wheel event handling in [Reader.tsx](cci:7://file:///Users/pratyushkongalla/space/other/flow/apps/reader/src/components/Reader.tsx:0:0-0:0) to prevent automatic chapter transitions, ensuring users can scroll freely within the current chapter.

These changes provide a fluid and responsive scrolling experience while maintaining clear chapter boundaries and user control over navigation.